### PR TITLE
fix Folder.info.uploadEmail

### DIFF
--- a/src/classes/BoxFolder.cls
+++ b/src/classes/BoxFolder.cls
@@ -484,7 +484,7 @@ public class BoxFolder extends BoxItem{
                     this.permissions = BoxFolder.parsePermission(value);
                 } else if (key == 'can_non_owners_invite') {
                     this.canNonOwnersInvite = Boolean.valueOf(value);
-                } else if (key == 'upload_email') {
+                } else if (key == 'folder_upload_email') {
                     this.uploadEmail = new BoxUploadEmail.Info(value);
                 }
             }

--- a/src/classes/BoxFolderTests.cls
+++ b/src/classes/BoxFolderTests.cls
@@ -132,6 +132,8 @@ public class BoxFolderTests {
     	
     	System.assertEquals(folderInfo.getValue('id'), folder.getId());
     	System.assertEquals(folderInfo.getValue('id'), folder.getInfo().getValue('id'));
+    	System.assertNotEquals(null, folderInfo.uploadEmail);
+    	System.assertEquals('upload.Picture.k13sdz1@u.box.com', folderinfo.uploadEmail.email);
     }
     
     public static testmethod void testGetApi() {


### PR DESCRIPTION
Fix for issue #19.  In the following code:

    BoxFolder.Info info = folder.getFolderInfo();
    BoxUploadEmail.Info emailInfo = info.uploadEmail;

`emailInfo` will always be null, because the class isn't parsing the json response correctly for the upload email info.  Per [the docs][1], the correct json tag is `folder_upload_email`; the code is checking for `upload_email`.

[1]: https://docs.box.com/reference#folder-object-1