### PR TITLE
Added support for named credentials

### DIFF
--- a/src/classes/BoxApiConnection.cls
+++ b/src/classes/BoxApiConnection.cls
@@ -36,6 +36,17 @@ public virtual class BoxApiConnection {
     public Long lastRefresh {get; set;}
     public Long expires {get; set;}
 
+    public Boolean canAuthenticate {get; set;}
+	
+    public static BoxApiConnection withNamedCredentials(String namedCredential, String uploadNamedCredential) {
+        BoxApiConnection api = new BoxApiConnection(null, null, null, null);
+        api.setAutoRefresh(false);
+        api.setBaseUrl(namedCredential);
+        api.setBaseUploadUrl(uploadNamedCredential);
+        api.canAuthenticate = false;
+        return api;
+    }
+    
     public BoxApiConnection(String accessToken) {
         this(null, null, accessToken, null);
     }
@@ -63,6 +74,7 @@ public virtual class BoxApiConnection {
         this.setUserAgent('Box Apex SDK v1.0.0');
         this.setLastRefresh(0);
         this.setExpires(0);
+	this.canAuthenticate = true;
     }
 
     public virtual void authenticate(String authCode) {

--- a/src/classes/BoxApiRequest.cls
+++ b/src/classes/BoxApiRequest.cls
@@ -109,7 +109,7 @@ public class BoxApiRequest {
         request.setEndpoint(this.url);
         request.setTimeout(this.timeout);
         if (this.api != null) {
-            if (this.shouldAuthenticate) {
+            if (this.api.canAuthenticate && this.shouldAuthenticate) {
                 request.setHeader('Authorization', 'Bearer ' + this.api.getAccessToken());
             }
             request.setHeader('User-Agent', this.api.getUserAgent());


### PR DESCRIPTION
Salesforce can handle oauth authorization and refresh.

Opted for a static factory method because of constructor clashes. It would probably be a good thing do refactor the other constructors into  withAccessToken and 3xwithClientId
